### PR TITLE
fix: ignore npm lifecycle scripts when installing

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -52,8 +52,8 @@ branches:
       required_status_checks:
         strict: false
         contexts:
-          - markdownlint
-          - commitlint
+          - markdownlint lint
+          - Validate PR title
       enforce_admins: true
       required_linear_history: false
       required_conversation_resolution: true

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -39,11 +39,10 @@ jobs:
         with:
           node-version-file: .tool-versions
           cache: npm
-          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+          cache-dependency-path: package-lock.json
 
       - name: Install Dependencies
-        run: npm ci
-        working-directory: ${{ inputs.working-directory }}
+        run: npm ci --ignore-scripts
 
       - uses: google-github-actions/auth@v1
         with:

--- a/.github/workflows/fireway-migrate.yml
+++ b/.github/workflows/fireway-migrate.yml
@@ -43,10 +43,9 @@ jobs:
         with:
           node-version-file: .tool-versions
           cache: npm
-          cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
+          cache-dependency-path: package-lock.json
       - name: Install Dependencies
-        run: npm ci
-        working-directory: ${{ inputs.working-directory }}
+        run: npm ci --ignore-scripts
 
       - uses: google-github-actions/auth@v1
         with:


### PR DESCRIPTION
`npm` runs all lifecycle scripts when running `npm ci`, even when these scripts are defined higher up in the directory structure. In `operationnezrouge`, this resulted in failure due to the absence of `husky` in devDependencies in the `functions` subproject.