### PR TITLE
chore: add an environment variable with the firebase environment on f…

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -52,7 +52,7 @@ branches:
       required_status_checks:
         strict: false
         contexts:
-          - markdownlint lint
+          - markdown lint
           - Validate PR title
       enforce_admins: true
       required_linear_history: false

--- a/.github/workflows/firebase-deploy.yml
+++ b/.github/workflows/firebase-deploy.yml
@@ -56,4 +56,5 @@ jobs:
       - name: Firebase deploy
         run: npx firebase deploy --force
         working-directory: ${{ inputs.working-directory }}
-
+        env:
+          ENVIRONMENT: ${{ inputs.environment }}


### PR DESCRIPTION
…irebase deploy

This is currently used in a script called hooked on the firebase hosting pre-deploy to check which environment we are currently deploying.