### PR TITLE
fix: add missing Slack API method to send failure notification

### DIFF
--- a/.github/workflows/deploy-firebase.yml
+++ b/.github/workflows/deploy-firebase.yml
@@ -80,6 +80,7 @@ jobs:
         if: ${{ !success() && inputs.slack-channel-id != '' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {

--- a/.github/workflows/fireway-migrate.yml
+++ b/.github/workflows/fireway-migrate.yml
@@ -123,6 +123,7 @@ jobs:
         if: ${{ !success() && inputs.slack-channel-id != '' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {

--- a/.github/workflows/pnpm-deploy-firebase.yml
+++ b/.github/workflows/pnpm-deploy-firebase.yml
@@ -75,6 +75,7 @@ jobs:
         if: ${{ !success() && inputs.slack-channel-id != '' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {

--- a/.github/workflows/pnpm-fireway-migrate.yml
+++ b/.github/workflows/pnpm-fireway-migrate.yml
@@ -117,6 +117,7 @@ jobs:
         if: ${{ !success() && inputs.slack-channel-id != '' }}
         uses: slackapi/slack-github-action@v2.0.0
         with:
+          method: chat.postMessage
           token: ${{ secrets.SLACK_BOT_TOKEN }}
           payload: |
             {


### PR DESCRIPTION
This commit fixes an error when a workflow fails and tries to notify Slack:

> SlackError: Missing input! A method must be decided to use the token
  provided.

See: https://github.com/slackapi/slack-github-action?tab=readme-ov-file#technique-2-slack-api-method